### PR TITLE
attach participant auth info to chat

### DIFF
--- a/platform/__tests__/core/chat.spec.js
+++ b/platform/__tests__/core/chat.spec.js
@@ -1,6 +1,7 @@
 import {
   Chat,
   ChatStartedEvent,
+  ChatParticipantIdentityLinkedEvent,
   ChatParticipantJoinedEvent,
   ChatParticipantLeftEvent,
   ChatEndedEvent,
@@ -79,6 +80,33 @@ describe('Chat', () => {
       expect(chat.dispatch)
         .toBeCalledWith('chatId', new ChatParticipantJoinedEvent('someone'));
       expect(chat.dispatch.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('when a chat participant identity is linked', () => {
+    beforeEach(() => {
+      chat.join('someone');
+      chat.linkIdentity('someone', 'someIdentity');
+    });
+    it('dispatches a chat participant identity linked event', () => {
+      expect(chat.dispatch)
+        .toBeCalledWith('chatId', new ChatParticipantIdentityLinkedEvent('someone', 'someIdentity'));
+    });
+    it('links an identity only once', () => {
+      chat.linkIdentity('someone', 'someIdentity');
+      expect(chat.dispatch)
+        .toBeCalledWith('chatId', new ChatParticipantIdentityLinkedEvent('someone', 'someIdentity'));
+      expect(chat.dispatch.mock.calls.filter((call) => call[1] instanceof ChatParticipantIdentityLinkedEvent).length).toBe(1);
+    });
+    it('dispatches an event when an identity link changes', () => {
+      chat.linkIdentity('someone', 'someOtherIdentity');
+      expect(chat.dispatch)
+        .toBeCalledWith('chatId', new ChatParticipantIdentityLinkedEvent('someone', 'someIdentity'));
+      expect(chat.dispatch)
+        .toBeCalledWith('chatId', new ChatParticipantIdentityLinkedEvent('someone', 'someOtherIdentity'));
+      expect(chat.dispatch)
+        .toBeCalledWith('chatId', new ChatParticipantIdentityLinkedEvent('someone', 'someOtherIdentity'));
+      expect(chat.dispatch.mock.calls.filter((call) => call[1] instanceof ChatParticipantIdentityLinkedEvent).length).toBe(2);
     });
   });
 

--- a/platform/__tests__/core/entity/entity.spec.js
+++ b/platform/__tests__/core/entity/entity.spec.js
@@ -1,0 +1,45 @@
+import {
+  BaseEntityRepository
+} from '../../../src/core/entity/entity';
+import {
+  Task
+} from '../../../src/core/task';
+
+
+describe('BaseEntityRepository', () => {
+
+  describe('when loading an entity', () => {
+    it('dispatches the event after an operation is executed', () => {
+      const dispatcher = (id, event) => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(event);
+          }, 25);
+        });
+      };
+      const store = {
+        replay: (id, handler, done) => {
+          setTimeout(() => {
+            done();
+          }, 25);
+        }
+      };
+      const repo = new BaseEntityRepository(dispatcher, store);
+      return repo.load(Task, '123').then((task) => {
+        task.submit();
+        return 'from_loaded_task_';
+      }).then((value) => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve('arbitrary_async_call_' + value);
+          }, 25);
+        });
+      }).then((value) => {
+        return 'events_dispatched_from_' + value;
+      }).then((value) => {
+        expect(value).toEqual('events_dispatched_from_arbitrary_async_call_from_loaded_task_');
+      });
+    });
+  });
+
+});

--- a/platform/__tests__/core/identity.spec.js
+++ b/platform/__tests__/core/identity.spec.js
@@ -4,8 +4,7 @@ import {
   AuthenticationSucceededEvent,
   AuthenticationFailedEvent,
   AuthenticationLockedEvent,
-  AuthenticationErrorEvent,
-  IdentityRegisteredEvent
+  AuthenticationErrorEvent
 } from '../../src/core/identity';
 import { UsernamePasswordCredentials } from '../../src/core/authentication';
 import { Clock } from '../../src/core/clock';
@@ -27,8 +26,9 @@ describe('Identity', () => {
   });
 
   const authenticatorYields = (result) => ({
-    authenticateUsernamePassword: () => {
+    authenticateUsernamePassword: (username) => {
       return result instanceof Error ? Promise.reject(result) : Promise.resolve({
+        username: username,
         success: result
       });
     }
@@ -42,7 +42,7 @@ describe('Identity', () => {
           expect(identity.dispatch)
             .toBeCalledWith('someId', new AuthenticationAttemptedEvent());
           expect(identity.dispatch)
-            .toBeCalledWith('someId', new AuthenticationSucceededEvent());
+            .toBeCalledWith('someId', new AuthenticationSucceededEvent('a'));
         });
     });
   });
@@ -92,16 +92,6 @@ describe('Identity', () => {
             .toBeCalledWith('someId', new AuthenticationErrorEvent());
         });
     });
-  });
-
-  it('can be registered once', () => {
-    identity.register('somePassword', 'aFirstName', 'aLastName', 'aPhoneNumber', 'aRole');
-    identity.register('somePassword', 'aFirstName', 'aLastName', 'aPhoneNumber', 'aRole');
-    expect(identity.dispatch)
-      .toBeCalledWith('someId',
-        new IdentityRegisteredEvent('someId', 'somePassword', 'aFirstName', 'aLastName', 'aPhoneNumber', 'aRole'));
-    expect(identity.dispatch.mock.calls.length).toBe(1);
-
   });
 
 });

--- a/platform/__tests__/core/registration.spec.js
+++ b/platform/__tests__/core/registration.spec.js
@@ -1,0 +1,32 @@
+import {
+  Registration,
+  IdentityRegisteredEvent
+} from '../../src/core/identity';
+import { Clock } from '../../src/core/clock';
+
+describe('Registration', () => {
+
+  let registration;
+
+  beforeEach(() => {
+    Clock.freeze(0);
+    registration = new Registration('someId');
+    registration.dispatch = jest.fn((id, event) => {
+      registration.apply(event);
+    });
+  });
+
+  afterEach(() => {
+    Clock.unfreeze();
+  });
+
+  it('can be registered once', () => {
+    registration.register('somePassword', 'aFirstName', 'aLastName', 'aPhoneNumber', 'aRole');
+    registration.register('somePassword', 'aFirstName', 'aLastName', 'aPhoneNumber', 'aRole');
+    expect(registration.dispatch)
+      .toBeCalledWith('someId',
+        new IdentityRegisteredEvent('someId', 'somePassword', 'aFirstName', 'aLastName', 'aPhoneNumber', 'aRole'));
+    expect(registration.dispatch.mock.calls.length).toBe(1);
+  });
+
+});

--- a/platform/__tests__/impl/chat_router.spec.js
+++ b/platform/__tests__/impl/chat_router.spec.js
@@ -16,7 +16,9 @@ describe('ChatRouter', () => {
     getChat() {
       return {
         send(req, res) {
-          chatResponse(res);
+          if(req) {
+            chatResponse(res);
+          }
         }
       };
     }
@@ -26,11 +28,9 @@ describe('ChatRouter', () => {
     subscribe(handler) {
       while (events.length > 0) {
         handler([events.pop()].map((event) => {
-          return {
-            name: event.constructor.name,
-            stream: 'someChatId',
-            payload: event
-          };
+          event.name = event.constructor.name;
+          event.streamId = 'someChatId';
+          return event;
         })[0]);
       }
     }

--- a/platform/run.sh
+++ b/platform/run.sh
@@ -44,6 +44,9 @@ export PUBLIC_URL
 export TWILIO_ACCOUNT_SID
 export TWILIO_AUTH_TOKEN
 export TWILIO_NUMBER_SID
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION
 export PORT
 
 echo "Serving from ${PUBLIC_URL}"

--- a/platform/src/core/api/event_api.ts
+++ b/platform/src/core/api/event_api.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import * as expressWS from 'express-ws';
 import {
   EventBus,
-  EventRecord
+  EntityEvent
 } from '../entity/entity';
 
 type WebSocket  = { on: Function, send : Function };
@@ -24,9 +24,9 @@ export function eventAPI(baseUrl : string, eventBus : EventBus) : { preConfigure
 
       const eventSubscriptions : { [key:string]:string[] } = {};
 
-      eventBus.subscribe((event : EventRecord) => {
-        if (eventSubscriptions[event.stream]) {
-          eventSubscriptions[event.stream]
+      eventBus.subscribe((event : EntityEvent) => {
+        if (eventSubscriptions[event.streamId]) {
+          eventSubscriptions[event.streamId]
             .forEach((wsConnectionId : string) => {
               if (wsConnections[wsConnectionId]) {
                 wsConnections[wsConnectionId].send(JSON.stringify(event));

--- a/platform/src/core/authentication.ts
+++ b/platform/src/core/authentication.ts
@@ -1,22 +1,53 @@
+import { uuid } from './entity/entity';
+
 export interface AuthenticationResult {
-  success : boolean;
+  username : string;
+  role : string;
+  success? : boolean;
 }
 
 export interface Authenticator {
   authenticateUsernamePassword(username : string, password : string) : Promise<AuthenticationResult>;
 }
 
-export interface Credentials {
-  authenticate(authenticator : Authenticator) : Promise<AuthenticationResult>;
+export abstract class Credentials {
+  private internalSessionId : string;
+
+  constructor(sessionId? : string) {
+    this.internalSessionId = sessionId || uuid();
+  }
+
+  public sessionId() : string {
+    return this.internalSessionId;
+  }
+
+  public abstract authenticate(authenticator : Authenticator) : Promise<AuthenticationResult>;
 }
 
-export class UsernamePasswordCredentials {
+export class AnonymousCredentials extends Credentials {
+  constructor() {
+    super();
+  }
+
+  public authenticate() : Promise<AuthenticationResult> {
+    return Promise.resolve({
+      username: 'visitor',
+      role: 'customer',
+      success: true
+    });
+  }
+}
+
+export class UsernamePasswordCredentials extends Credentials {
   private username : string;
   private password : string;
-  constructor(username : string, password : string) {
+
+  constructor(username : string, password : string, sessionId? : string) {
+    super(sessionId);
     this.username = username;
     this.password = password;
   }
+
   public authenticate(authenticator : Authenticator) : Promise<AuthenticationResult> {
     return authenticator.authenticateUsernamePassword(this.username, this.password);
   }

--- a/platform/src/core/chat_service.ts
+++ b/platform/src/core/chat_service.ts
@@ -19,6 +19,17 @@ export class ChatService {
       });
   }
 
+  public linkIdentity(chatId : string, participant : string, identityId : string) : void {
+    this.entityRepository
+      .load(Chat, chatId)
+      .then((chat : Chat) => {
+        chat.linkIdentity(participant, identityId);
+      })
+      .catch((error : Error) => {
+        throw error;
+      });
+  }
+
   public postMessage(chatId : string, fromParticipant : string, text : string) : void {
     this.entityRepository
       .load(Chat, chatId)

--- a/platform/src/core/identity_service.ts
+++ b/platform/src/core/identity_service.ts
@@ -1,41 +1,57 @@
-import { Identity } from './identity';
-import { Authenticator, Credentials } from './authentication';
-import { EntityRepository } from './entity/entity';
+import { Identity, Registration } from './identity';
+import { Authenticator, AuthenticationResult, Credentials } from './authentication';
+import { EntityRepository, uuid } from './entity/entity';
+import * as jwts from 'jwt-simple';
 
 export class IdentityVO {
   public username : string;
+  public role : string;
+  public sessionId : string;
+  public jwt : string;
 
-  constructor(username : string) {
+  constructor(username : string, role : string, sessionId : string, jwt? : string) {
     this.username = username;
+    this.role = role;
+    this.sessionId = sessionId;
+    this.jwt = jwt;
   }
 }
 
 export class IdentityService {
   private authenticator : Authenticator;
   private entityRepository : EntityRepository;
+  private jwtSecret : string;
 
-  constructor(entityRepository : EntityRepository, authenticator : Authenticator) {
+  constructor(entityRepository : EntityRepository, authenticator : Authenticator, jwtSecret : string) {
     this.entityRepository = entityRepository;
     this.authenticator = authenticator;
+    this.jwtSecret = jwtSecret;
   }
 
-  public authenticate(username : string, credentials : Credentials) : Promise<IdentityVO> {
+  public decode(jwt : string) : IdentityVO {
+    const unverifiedJwt : IdentityVO = <IdentityVO> jwts.decode(jwt, null, true);
+    return <IdentityVO> jwts.decode(jwt, this.jwtSecret + unverifiedJwt.sessionId);
+  }
+
+  public authenticate(credentials : Credentials) : Promise<IdentityVO> {
     return this.entityRepository
-      .load(Identity, username)
+      .load(Identity, credentials.sessionId())
       .then((identity : Identity) => {
         return identity
           .authenticate(credentials, this.authenticator);
       })
-      .then(() => {
-        return new IdentityVO(username);
+      .then((authResult : AuthenticationResult) => {
+        const sessionId : string = credentials.sessionId() || uuid();
+        const jwt : string = jwts.encode(new IdentityVO(authResult.username, authResult.role, sessionId), this.jwtSecret + sessionId);
+        return new IdentityVO(authResult.username, authResult.role, sessionId, jwt);
       });
   }
 
   public register(username : string, password : string, firstName : string, lastName : string, phoneNumber : string, role : string) : void {
     this.entityRepository
-      .load(Identity, username)
-      .then((identity : Identity) => {
-        identity.register(password, firstName, lastName, phoneNumber, role);
+      .load(Registration, username)
+      .then((registration : Registration) => {
+        registration.register(password, firstName, lastName, phoneNumber, role);
       })
       .catch((error : Error) => {
         console.error(error);

--- a/platform/src/core/task.ts
+++ b/platform/src/core/task.ts
@@ -1,15 +1,11 @@
 import { Entity, EntityEvent } from './entity/entity';
-import { Clock } from './clock';
 
-export class TaskEvent implements EntityEvent {
-  public time : number;
+export class TaskEvent extends EntityEvent {
   public taskData : { [key:string]:string};
   public worker : string;
-  public name : string;
   constructor(taskData : { [key:string]:string}) {
-    this.time = Clock.now();
+    super();
     this.taskData = taskData;
-    this.name = this.constructor.name;
   }
 }
 

--- a/platform/src/impl/fulfillment_processor.js
+++ b/platform/src/impl/fulfillment_processor.js
@@ -1,25 +1,27 @@
+import { ChatReadyForFulfillmentEvent } from '../core/chat';
+
 module.exports = (eventBus, chatService) => {
 
   eventBus.subscribe((event) => {
-    if (event.name === 'ChatReadyForFulfillmentEvent') {
+    if (event instanceof ChatReadyForFulfillmentEvent) {
       // implement real fulfillment logic here
-      if(event.payload.payload.intentName === 'Welcome') {
+      if(event.payload.intentName === 'Welcome') {
         // example of escalating to agent
         chatService.postMessage(
-          event.stream,
-          event.payload.queue,
+          event.streamId,
+          event.queue,
           'I\'m sorry, something went wrong, let me pass you over to a human agent');
         setTimeout(function() {
           // give it time to catch up
-          chatService.leaveChat(event.stream, event.payload.queue);
-          chatService.transferTo(event.stream, 'agentChatQueue');
+          chatService.leaveChat(event.streamId, event.queue);
+          chatService.transferTo(event.streamId, 'agentChatQueue');
         }, 500);
       } else {
         chatService.postMessage(
-          event.stream,
-          event.payload.queue,
-          `${event.payload.payload.intentName} fulfilled!`);
-        chatService.endChat(event.stream);
+          event.streamId,
+          event.queue,
+          `${event.payload.intentName} fulfilled!`);
+        chatService.endChat(event.streamId);
       }
 
     }

--- a/platform/src/impl/in_mem_authenticator.ts
+++ b/platform/src/impl/in_mem_authenticator.ts
@@ -1,33 +1,32 @@
 import { Authenticator, AuthenticationResult} from '../core/authentication';
-import { Identity, IdentityRegisteredEvent } from '../core/identity';
-import { EntityRepository, EventBus, EventRecord } from '../core/entity/entity';
+import { Registration, IdentityRegisteredEvent } from '../core/identity';
+import { EntityRepository, EventBus, EntityEvent } from '../core/entity/entity';
 
-const users : {} = {};
+const registrations : { [key:string]:IdentityRegisteredEvent } = {};
 
 export class InMemoryAuthenticator implements Authenticator {
 
   constructor(entityRepository : EntityRepository, eventBus : EventBus) {
 
     // Load user data into map
-    eventBus.subscribe((event : EventRecord) => {
-      if (event.name === 'IdentityRegisteredEvent') {
-        const identityRegisteredEvent : IdentityRegisteredEvent = (<IdentityRegisteredEvent>event.payload);
-        users[event.stream] = identityRegisteredEvent.password;
+    eventBus.subscribe((event : EntityEvent) => {
+      if (event instanceof IdentityRegisteredEvent) {
+        registrations[event.streamId] = event;
       }
     }, {replay: true});
 
     // Register some users ...
-    entityRepository.load(Identity, 'demouser')
-      .then((identity : Identity) => {
-        identity.register('password1', 'John', 'Doe', '+15555555555', 'customer');
+    entityRepository.load(Registration, 'demouser')
+      .then((registration : Registration) => {
+        registration.register('password1', 'John', 'Doe', '+15555555555', 'customer');
       })
       .catch((err : Error) => {
         console.error(err);
       });
 
-    entityRepository.load(Identity, 'demoagent')
-      .then((identity : Identity) => {
-        identity.register('password1', 'Kermit', 'Frog', process.env.DEMO_AGENT_PHONE_NUMBER || '+15555555555', 'agent');
+    entityRepository.load(Registration, 'demoagent')
+      .then((registration : Registration) => {
+        registration.register('password1', 'Kermit', 'Frog', process.env.DEMO_AGENT_PHONE_NUMBER || '+15555555555', 'agent');
       })
       .catch((err : Error) => {
         console.error(err);
@@ -35,8 +34,14 @@ export class InMemoryAuthenticator implements Authenticator {
   }
 
   public authenticateUsernamePassword(username : string, password : string) : Promise<AuthenticationResult> {
-    return Promise.resolve({
-      success: users[username] === password
+    return Promise.resolve(!registrations[username] ? {
+      username: username,
+      role: 'unknown',
+      success: false
+    } : {
+      username: username,
+      role: registrations[username].role,
+      success: registrations[username].password === password
     });
   }
 

--- a/platform/src/impl/task_processor.js
+++ b/platform/src/impl/task_processor.js
@@ -1,21 +1,22 @@
+import { ChatTransferredEvent } from '../core/chat';
+import { TaskCompletedEvent } from '../core/task';
+
 module.exports = (eventBus, taskService, chatService) => {
 
   eventBus.subscribe((event) => {
-    switch (event.name) {
-      case 'ChatTransferredEvent':
-        if (event.payload.toQueue === 'agentChatQueue') {
-          taskService.submitTask('ccaas', {
-            channel: 'chat',
-            chatId: event.stream
-          }).catch((error) => {
-            console.error('failed to create task', error);
-          });
-        }
-        break;
-      case 'TaskCompletedEvent':
-        if (event.payload.taskData.chatId) {
-          chatService.endChat(event.payload.taskData.chatId);
-        }
+    if(event instanceof ChatTransferredEvent) {
+      if (event.toQueue === 'agentChatQueue') {
+        taskService.submitTask('ccaas', {
+          channel: 'chat',
+          chatId: event.streamId
+        }).catch((error) => {
+          console.error('failed to create task', error);
+        });
+      }
+    } else if (event instanceof TaskCompletedEvent) {
+      if (event.taskData.chatId) {
+        chatService.endChat(event.taskData.chatId);
+      }
     }
   });
 

--- a/portal/src/api/ajax.js
+++ b/portal/src/api/ajax.js
@@ -1,6 +1,13 @@
 import reqwest from 'reqwest';
+import { jwt } from './identity';
 
 const ajax = (opts) => {
+  opts = opts || {};
+  const token = jwt();
+  if(token) {
+    opts.headers = opts.headers || {};
+    opts.headers.jwt = token;
+  }
   return new Promise((resolve, reject) => {
     opts.success = (res) => {
       resolve(res);

--- a/portal/src/api/tasks.js
+++ b/portal/src/api/tasks.js
@@ -1,5 +1,5 @@
 import ajax from './ajax';
-import { identity, jwt } from './identity';
+import { identity } from './identity';
 import { getChatLog, startChat, leaveChat } from './chat';
 import { subscribeTo } from './events';
 
@@ -7,10 +7,7 @@ export const getTasks = () => {
   const id = identity();
   return ajax({
     url: `/api/worker/${id.username}/tasks`,
-    method: 'get',
-    headers: {
-      jwt: jwt()
-    }
+    method: 'get'
   }).then((result) => {
     return Object.keys(result).map((taskId) => result[taskId]);
   }).then((tasks) => populateTasks(tasks));
@@ -21,9 +18,6 @@ export const markTaskComplete = (task, reason) => {
   return ajax({
     url: `/api/tasks/${task.taskId}`,
     method: 'post',
-    headers: {
-      jwt: jwt()
-    },
     data: {
       command: 'complete',
       reason: reason

--- a/portal/src/component/task_detail.js
+++ b/portal/src/component/task_detail.js
@@ -23,16 +23,16 @@ export class TaskDetail extends Component {
       if (/^ChatParticipant(Joined|Left)Event$/.test(chatLog.name)) {
         const eventType = /^ChatParticipant(Joined|Left)Event$/.exec(chatLog.name)[1];
         return {
-          messageId: `${JSON.stringify(chatLog.payload)}`,
+          messageId: `${JSON.stringify(chatLog)}`,
           messageType: 'status',
-          text: `${chatLog.payload.participant} has ${eventType.toLowerCase()} the chat`
+          text: `${chatLog.participant} has ${eventType.toLowerCase()} the chat`
         }
       }
       return {
-        messageId: chatLog.payload.messageId,
-        direction: chatLog.payload.fromParticipantRole === 'customer' ? 'incoming' : 'outgoing',
-        from: chatLog.payload.fromParticipant,
-        text: chatLog.payload.text
+        messageId: chatLog.messageId,
+        direction: chatLog.fromParticipantRole === 'customer' ? 'incoming' : 'outgoing',
+        from: chatLog.fromParticipant,
+        text: chatLog.text
       }
     };
     const prepareChatMessages = (task) => {

--- a/portal/src/index.js
+++ b/portal/src/index.js
@@ -1,5 +1,4 @@
 import { render } from 'react-dom';
-import jwts from 'jwt-simple';
 import page from 'page';
 import Container from './component/container';
 import './style/theme.scss';
@@ -85,12 +84,9 @@ const sideEffect = (command, model) => {
         },
         message: (msg) => {
           const message = JSON.parse(msg.data);
-          dispatch({
-            type: RECEIVE_ENTITY_EVENT,
-            stream: message.stream,
-            name: message.name,
-            event: message.payload
-          });
+          dispatch(Object.assign({}, message, {
+            type: RECEIVE_ENTITY_EVENT
+          }));
         }
       });
 
@@ -135,37 +131,38 @@ const sideEffect = (command, model) => {
       }
       break;
     case RECEIVE_ENTITY_EVENT:
+      console.log('ree', command);
       if (command.name === 'ChatMessagePostedEvent') {
-        if (command.event.fromParticipant !== identity().username) {
+        if (command.fromParticipant !== identity().username) {
           setTimeout(() => {
             dispatch({
               type: INCOMING_CHAT_MESSAGE_POSTED,
-              messageId: command.event.messageId,
-              id: command.stream,
-              from: command.event.fromParticipant,
-              text: command.event.text
+              messageId: command.messageId,
+              id: command.streamId,
+              from: command.fromParticipant,
+              text: command.text
             });
           }, 500);
         } else {
           dispatch({
             type: OUTGOING_CHAT_MESSAGE_POSTED,
-            messageId: command.event.messageId,
-            id: command.stream,
-            from: command.event.fromParticipant,
-            text: command.event.text
+            messageId: command.messageId,
+            id: command.streamId,
+            from: command.fromParticipant,
+            text: command.text
           });
         }
       } else if (/^ChatParticipant(Joined|Left)Event$/.test(command.name)) {
         const eventType = /^ChatParticipant(Joined|Left)Event$/.exec(command.name)[1];
         dispatch({
           type: CHAT_STATUS_POSTED,
-          messageId: `${JSON.stringify(command.event)}`,
+          messageId: `${JSON.stringify(command)}`,
           messageType: 'status',
-          id: command.stream,
-          text: `${command.event.participant} has ${eventType.toLowerCase()} the chat`
+          id: command.streamId,
+          text: `${command.participant} has ${eventType.toLowerCase()} the chat`
         });
       } else if (command.name === 'WorkerTaskStatusUpdatedEvent') {
-        populateTasks(command.event.task).then((tasks) => {
+        populateTasks(command.task).then((tasks) => {
           const url = `/agent/task/${tasks[0].taskId}`;
           growl({
             title: `Task ${tasks[0].status}`,
@@ -184,7 +181,7 @@ const sideEffect = (command, model) => {
       } else if (command.name === 'WorkerTaskDataUpdatedEvent') {
         dispatch({
           type: TASK_RECEIVED,
-          task: command.event.task
+          task: command.task
         });
       }
       break;
@@ -218,7 +215,7 @@ const sideEffect = (command, model) => {
             });
           });
         }).catch((err) => {
-          console.log(err);
+          signout();
           dispatch({
             type: AUTHENTICATION_FAILED
           });


### PR DESCRIPTION
- add session concept to attach auth to
- pass chat session to chat destination on each request
- use consistent event structure for replay and replayAll
- delay entity repository load promise chain execution until entity events have been dispatched